### PR TITLE
Add 'No Config' mode to manual segmenter (display raw video without rotation/crop)

### DIFF
--- a/manual_segment.py
+++ b/manual_segment.py
@@ -99,6 +99,7 @@ class ManualSegmenter:
 
         ttk.Button(row1, text="Load Video", command=self.load_video).pack(side=tk.LEFT)
         ttk.Button(row1, text="Load Config", command=self.load_config).pack(side=tk.LEFT)
+        ttk.Button(row1, text="No Config", command=self.load_no_config).pack(side=tk.LEFT)
         ttk.Button(row1, text="Prev Frame", command=self.prev_frame).pack(side=tk.LEFT)
         ttk.Button(row1, text="Next Frame", command=self.next_frame).pack(side=tk.LEFT)
         ttk.Button(row1, text="Prev Plume", command=self.prev_plume).pack(side=tk.LEFT)
@@ -268,12 +269,7 @@ class ManualSegmenter:
             # seg = (np.asarray(seg) * plume_mask[None, :, :]).astype(np.float32, copy=False)
             seg = (np.asarray(seg) ).astype(np.float32, copy=False)
             self.plume_videos.append(seg)
-        self.plume_masks = [
-            [np.zeros(seg[0].shape, dtype=np.uint8) for _ in range(seg.shape[0])]
-            for seg in self.plume_videos
-        ]
-        self.current_frame = 0
-        self.current_plume = 0
+        self._set_plume_videos(self.plume_videos)
 
         self.config_path = path
         self.config_values = cfg
@@ -285,6 +281,34 @@ class ManualSegmenter:
         self.rotation_offset_deg = float(offset)
 
         self.update_image()
+
+    def load_no_config(self):
+        if self.video is None:
+            messagebox.showinfo("Info", "Load a video first")
+            return
+
+        raw_video = np.asarray(self.video, dtype=np.float32)
+        self._set_plume_videos([raw_video])
+
+        self.config_path = None
+        self.config_values = {}
+        self.n_plumes = 1
+        self.centre_x = None
+        self.centre_y = None
+        self.inner_radius = 0
+        self.outer_radius = 0
+        self.rotation_offset_deg = 0.0
+
+        self.update_image()
+
+    def _set_plume_videos(self, plume_videos):
+        self.plume_videos = plume_videos
+        self.plume_masks = [
+            [np.zeros(seg[0].shape, dtype=np.uint8) for _ in range(seg.shape[0])]
+            for seg in self.plume_videos
+        ]
+        self.current_frame = 0
+        self.current_plume = 0
 
     # ---------------------------------------------------------------
     #                       Navigation


### PR DESCRIPTION
### Motivation
- Provide an option to view and annotate the original 3D video directly (no rotation/crop) for cases where the pipeline configuration is not needed or when annotating raw frames for CNN training.
- Allow creating datasets where the raw video and labels remain aligned without geometric preprocessing, facilitating experiments with direct 3D augmentations.
- Consolidate plume/mask initialization to ensure consistent behavior between configured and no-config flows.

### Description
- Added a `No Config` button to the main toolbar that invokes `load_no_config()` next to the existing `Load Config` control.
- Implemented `load_no_config()` which loads the raw video into a single plume stream (`n_plumes = 1`) and clears config-derived geometry fields (`config_path`, `config_values`, `centre_x`, `centre_y`, etc.).
- Refactored plume and mask setup into a helper `_set_plume_videos()` which initializes `self.plume_videos`, `self.plume_masks`, `self.current_frame`, and `self.current_plume`, and updated `load_config()` to reuse this helper.

### Testing
- Ran `python -m py_compile manual_segment.py` and compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b3d6e7988328a55136fea28c90be)